### PR TITLE
Troubleshoot gunicorn command not found

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --bind 0.0.0.0:$PORT server:app

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: restaurant-pos
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn --bind 0.0.0.0:$PORT server:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask-cors
 supabase
 cryptography
 bcrypt
+gunicorn


### PR DESCRIPTION
Add Gunicorn to dependencies and configure deployment for Render to resolve 'command not found' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c8ff482-7112-4dbf-ba9a-ba2a93e10c96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c8ff482-7112-4dbf-ba9a-ba2a93e10c96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

